### PR TITLE
Fixed get_current_table and get_current_table_without_account in receive_sqs_message.py

### DIFF
--- a/Front-End/src/pages/Home.js
+++ b/Front-End/src/pages/Home.js
@@ -4,7 +4,7 @@
 import React from 'react';
 
 export const Home = () => <div className="default">
-    <br></br><center>GitHub Repo: <a href="https://github.com/awslabs/aws-multi-account-viewer">here</a>
+    <br></br><center>GitHub Repo: <a href="https://github.com/kyhau/aws-multi-account-viewer">here</a>
     <br></br>
     <br></br><img src="https://aws-multi-account-viewer-site.s3-ap-southeast-2.amazonaws.com/frontpage.png" alt="Overview"></img>
 </center></div>;

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -24,3 +24,6 @@
     around the same time (due to eventually consistency nature of DynamoDB).
 11. Updated [Front-End/src/components/Navigation.js](Front-End/src/components/Navigation.js) to fix the label of
     "All Network Interfaces".
+12. Fixed the `get_current_table` and `get_current_table_without_account` functions in
+    [Back-End/lambdas/receive_sqs_message.py](Back-End/lambdas/receive_sqs_message.py) - original code did not
+    handle pagination resulting not retrieving all existing entries from the DynamoDB table.


### PR DESCRIPTION
*Description of changes:*
Fixed the `get_current_table` and `get_current_table_without_account` functions in Back-End/lambdas/receive_sqs_message.py - the original code did not handle pagination, resulting not retrieving all matched entries from the DynamoDB table.
